### PR TITLE
Fix for android

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub trait FilePath {
 }
 
 impl FilePath for File {
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     fn path(&self) -> io::Result<PathBuf> {
         use std::path::Path;
 


### PR DESCRIPTION
I tried building a crate that depends on this library on Termux, a terminal emulator that emulates a Linux environment within Android, and got hit with an error, as the `path` function wasn't implemented for the OS.